### PR TITLE
Fixes the incorrect timestamp bug on the embed page, adds GTM

### DIFF
--- a/app/templates/components/embed-masthead.hbs
+++ b/app/templates/components/embed-masthead.hbs
@@ -5,6 +5,6 @@
 <div class="masthead-component__spacer"></div>
 
 <div class="masthead-component__timestamp">
-  <span>Last updated: 7/18/2017 8:44 A.M. PDT</span>
+  <span>Last updated: {{moment-format model.fire.updatedAt 'MM/DD/YYYY h:mm A'}}</span>
 </div>
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -25,13 +25,13 @@ module.exports = function(environment) {
       // when it is created
     },
     metricsAdapters: [
-      // {
-      //   name: 'GoogleTagManager',
-      //   environments: ['development', 'production'],
-      //   config: {
-      //     id: 'GTM-585PL29'
-      //   }
-      // }
+      {
+        name: 'GoogleTagManager',
+        environments: ['development', 'production'],
+        config: {
+          id: 'GTM-585PL29'
+        }
+      },
       {
         name: 'GoogleAnalytics',
         environments: ['development', 'production'],

--- a/config/environment.js
+++ b/config/environment.js
@@ -31,21 +31,6 @@ module.exports = function(environment) {
         config: {
           id: 'GTM-585PL29'
         }
-      },
-      {
-        name: 'GoogleAnalytics',
-        environments: ['development', 'production'],
-        config: {
-          id: 'UA-624724-1',
-          // Use `analytics_debug.js` in development
-          debug: environment === 'development',
-          // Use verbose tracing of GA events
-          trace: environment === 'development',
-          // Ensure development env hits aren't sent to GA
-          sendHitTask: environment !== 'development',
-          // Specify Google Analytics plugins
-          require: ['linker', 'displayfeatures']
-        }
       }
     ],
     moment: {


### PR DESCRIPTION
It looks like the timestamp in the embed page, such as this: https://firetracker.scpr.org/holy-fire-orange-2018/embed, is actually hardcoded. The changes proposed here should access the correct `updatedAt` value and format it correctly.

This PR also uncomments the GTM implementation that Ben had previously implemented. This will allow us to use a chartbeat script from GTM. Ben also set up a separate Google Analytics adapter, but I'm undecided as to whether I should remove it or not.