### PR TITLE
Fix/logo quality

### DIFF
--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -85,6 +85,9 @@ html
   border-bottom-left-radius: 100px 2px
   opacity: 1.0
 
+.kpcc-laist-logos
+  pointer-events: none
+
 @media (max-width: $l-med-breakpoint)
   .footer-component
     @include footer-component--med

--- a/app/templates/components/footer-component.hbs
+++ b/app/templates/components/footer-component.hbs
@@ -5,7 +5,7 @@
     {{/link-to}}
     <div class="footer-component__logos__pipe"></div>
     <a class="footer-component__logos__kpcc" href="https://www.scpr.org/" target="_blank">
-      <img src="/images/kpcc-laist-logo-orange.svg" />
+      <object class="kpcc-laist-logos" data="/images/kpcc-laist-logo-orange.svg" type="image/svg+xml" />
     </a>
   </div>
   <a class="footer-component__call-to-action" href="https://scprcontribute.scpr.org/">

--- a/app/templates/components/masthead-component.hbs
+++ b/app/templates/components/masthead-component.hbs
@@ -8,9 +8,9 @@
   <p class="masthead-component__parent-logo__img--full masthead-component__special-project">
     A special project from
   </p>
-  <img class="masthead-component__parent-logo__img--full" src="/images/kpcc-laist-logo.svg">
+  <object class="masthead-component__parent-logo__img--full kpcc-laist-logos" data="/images/kpcc-laist-logo.svg" type="image/svg+xml" />
   <span class="masthead-component__parent-logo__built-by">Built by</span>
-  <img class="masthead-component__parent-logo__img--mobile" src="/images/kpcc-laist-logo.svg">
+  <object class="masthead-component__parent-logo__img--mobile kpcc-laist-logos" data="/images/kpcc-laist-logo.svg" type="image/svg+xml" />
 </a>
 
 <div class="masthead-component__pipe"></div>

--- a/app/templates/embed.hbs
+++ b/app/templates/embed.hbs
@@ -48,7 +48,7 @@
       </div>
       <a href="https://scpr.org/" class="fire-embed__header__foot" target="_blank">
         <span class="fire-embed__special-project">A special project from</span>
-        <img class="fire-embed__header__foot__img" src="/images/kpcc-laist-logo.svg">
+        <object class="fire-embed__header__foot__img kpcc-laist-logos" data="/images/kpcc-laist-logo.svg" type="image/svg+xml" />
       </a>
     </div>
 
@@ -72,7 +72,7 @@
       </p>
       <a href="https://scpr.org" class="fire-embed__footer__kpcc-laist-logo" target="_blank">
         <span class="fire-embed__footer__special-project">A special project from</span>
-        <img class="fire-embed__footer__img--mobile" src="/images/kpcc-laist-logo-black.svg" />
+        <object class="fire-embed__footer__img--mobile kpcc-laist-logos" data="/images/kpcc-laist-logo-black.svg" type="image/svg+xml" />
       </a>
     </div>
   </div>

--- a/app/templates/embed.hbs
+++ b/app/templates/embed.hbs
@@ -48,7 +48,7 @@
       </div>
       <a href="https://scpr.org/" class="fire-embed__header__foot" target="_blank">
         <span class="fire-embed__special-project">A special project from</span>
-        <object class="fire-embed__header__foot__img kpcc-laist-logos" data="/images/kpcc-laist-logo.svg" type="image/svg+xml" />
+        <embed class="fire-embed__header__foot__img kpcc-laist-logos" src="/images/kpcc-laist-logo.svg"/>
       </a>
     </div>
 


### PR DESCRIPTION
In Safari all of the KPCC + Laist logos were a bit blurry. I found out that the cause of that is when you put an svg into an img tag it locks the size of base image. So each browser will determine the quality of the logo and Safari was handling it differently than the other browsers. 

In this PR, I put all the logo svgs into an object or an embed tag (had to use an embed because in Safari resizing the screen made a logo disappear) which gave a clear quality to all the logos in Safari. Also, I had to add a pointer-events: none style because if you use an object tag inside an anchor tag it does not become a clickable link unless the pointer-events is none.

